### PR TITLE
Add self-mutating CodePipeline with Beta/Prod stages and SSM connection ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,27 @@ The core service is built on two Constructs: `HiScoresLogger` and `AggregatingTi
 
 The first uses a CloudWatch EventBridge to trigger an Orchestrator Lambda, which reads your configuration file and sends instruction messages to an SQS Queue. A Lambda Function listens to this queue, and when it receives a request for a username, it queries the HiScores API, parses the response, and saves it to a table.
 
-The second is a Dynmo Table with a Lambda Function subscribed to write events. When the table is written to, the Lambda aggregates the new record into a daily sum row. The table also comes with a queryer Lambda Function and API Gateway Endpoint for easy reading with configurable daily aggregation.
+The second is a DynamoDB Table with a Lambda Function subscribed to write events. When the table is written to, the Lambda aggregates the new record into a daily sum row. The table also comes with a query Lambda Function and API Gateway Endpoint for easy reading with configurable daily aggregation.
+
+# CI/CD Architecture
+
+Deployments are managed by a self-mutating AWS CodePipeline. Every push to `mainline` triggers a full pipeline run:
+
+1. **Synth** — CDK synthesizes CloudFormation templates from source.
+2. **Beta** — A full isolated copy of the stack is deployed. The EventBridge schedule is disabled so it never polls the live HiScores API.
+3. **Integration Tests** — A smoke test triggers the ingest API and verifies data is returned by the query API. This stage must pass before production is updated.
+4. **Prod** — The production `HiscoresTrackerStack` is updated in-place, preserving all existing DynamoDB data.
+
+The pipeline is self-mutating: changes to the pipeline definition itself are applied automatically on the next run.
 
 # Getting Started
-You can create an instance of this service for yourself using AWS CDK. Follow these steps to get started.
+
+You can create an instance of this service for yourself using AWS CDK. The initial setup deploys the pipeline; all subsequent changes deploy automatically on push.
 
 ## Prerequisites
 
 ### 1. Install Python
-You can find the latest release at https://www.python.org/downloads/. As of writing, we are on 3.8.16.
+You can find the latest release at https://www.python.org/downloads/. Python 3.9 or later is required.
 
 ### 2. Create a free-tier AWS account
 If you don't already have one, go to https://aws.amazon.com/free and sign up.
@@ -50,73 +62,92 @@ With the IAM user you created above, follow [these instructions](https://docs.aw
 npm install -g aws-cdk@2.0.0
 ```
 
-## Clone the repo
+### 7. Create a GitHub CodeStar connection
+
+The pipeline pulls source from GitHub. Create a connection in the AWS console under **CodePipeline → Settings → Connections**, or via the CLI:
+
+```bash
+aws codestar-connections create-connection \
+    --provider-type GitHub \
+    --connection-name cdk-hiscores-tracker
+```
+
+Complete the OAuth handshake in the console to move the connection from `PENDING` to `AVAILABLE`. Copy the resulting connection ARN.
+
+### 8. Store the connection ARN in SSM Parameter Store
+
+```bash
+aws ssm put-parameter \
+    --name /hiscores-tracker/github-connection-arn \
+    --value "arn:aws:codestar-connections:REGION:ACCOUNT:connection/YOUR-ID" \
+    --type String
+```
+
+The pipeline reads this value at synth time so the ARN is never committed to source.
+
+## Clone and configure the repo
 
 ```bash
 git clone https://github.com/awerchniak/cdk-hiscores-tracker.git
 cd cdk-hiscores-tracker
 ```
 
-## Configure
-Edit the file located at `lambda/orchestrator/players.txt` to use the usernames of the players you would like to track (minimum: 1).
+Edit `lambda/orchestrator/players.txt` to list the usernames you want to track (one per line, minimum 1).
 
-## Build and deploy
+## Deploy the pipeline
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 cdk bootstrap aws://ACCOUNT-NUMBER/REGION
-cdk deploy
+cdk deploy HiscoresPipelineStack
 ```
 
-You can now navigate to the AWS console and see your resources created. Take a look at the Service Overview below to get oriented. In particular, see DynamoDB and Lambda.
+This creates the CodePipeline. The pipeline immediately runs its first execution, deploying Beta and then Prod automatically. You can monitor progress in the AWS CodePipeline console.
 
-At the end of the terminal output, you should see something like:
+After the initial deploy, **all future changes deploy automatically** when you push to `mainline`. You do not need to run `cdk deploy` again.
+
+## Finding your API endpoints
+
+After the pipeline completes its first run, the Prod stack outputs are visible in CloudFormation:
+
 ```
-Outputs:
-HiscoresTrackerStack.HiScoresATSTQueryHiScoresDataEndpointB5BC150F = https://511h1wh89e.execute-api.us-east-1.amazonaws.com/prod/
-HiscoresTrackerStack.TriggerHiScoresLogEventEndpointBCAB06A2 = https://n2mtfqtg7h.execute-api.us-east-1.amazonaws.com/prod/
+HiscoresTrackerStack.HiScoresATSTQueryHiScoresDataEndpoint = https://<id>.execute-api.us-east-1.amazonaws.com/prod/
+HiscoresTrackerStack.TriggerHiScoresLogEventEndpoint       = https://<id>.execute-api.us-east-1.amazonaws.com/prod/
 ```
 
-Your Stack name and URL will be slightly different. Make note of these URLs; they are public APIs
-you can use to interact with your service.
+**QueryHiScoresDataEndpoint** — `GET` with query parameters `player`, `startTime`, `endTime`.
 
-The first, QueryHiScoresDataEndpoint, is a public Rest API you can call to query your stats datatabse. It supports `GET` and takes 3 parameters: `{player: str, startTime: str, endTime: str}`.
-
-The second, TriggerHiScoresLogEventEndpoint, is a public Rest API you can call to trigger a save event to your stats database. It supports `POST` and takes no parameters.
+**TriggerHiScoresLogEventEndpoint** — `POST` with no parameters. Triggers an immediate ingest for all configured players.
 
 ## Cleanup
 
-When you are finished, you can destroy all resources with:
+To tear down all resources:
 
 ```bash
-cdk destroy
+cdk destroy HiscoresPipelineStack
 ```
+
+Note: this will also remove the Beta and Prod stacks managed by the pipeline. The Prod DynamoDB table has deletion protection; you will need to disable it manually before the destroy completes.
 
 # Contributing
 
-We welcome contributions. If you would like to contribute, please fork the repo and issue a pull request with your changes. We will respond to all PRs within a 1 week SLA. Prior to submitting your pull request, ensure all tests are passing.
+We welcome contributions. Fork the repo and open a pull request against `mainline`. We will respond within one week.
 
-## Running unit tests
+Merging to `mainline` triggers the pipeline automatically. The integration test suite runs against the Beta stage before any change reaches production.
+
+## Running unit tests locally
 ```bash
 pip install -r requirements-dev.txt
 bash run_tests.sh
 ```
 
-## Running integration tests
-This repo contains an extremely simple integration test that triggers a save event and verifies that the data is returned in a query. To run it, make note of your Log API and Query API from the "Deploy" section, and issue the following command:
+## Running integration tests locally
+To run the integration test against a manually deployed stack, note your trigger and query URLs from the CloudFormation outputs and run:
 
 ```bash
 python run_integration_test.py \
     -i YOUR_TRIGGER_LOG_EVENT_URL \
     -o YOUR_QUERY_DATABASE_URL
-```
-
-For example, using the example deployment from above, the tests can be run like the following:
-
-```bash
-python run_integration_test.py \
-    -i https://n2mtfqtg7h.execute-api.us-east-1.amazonaws.com/prod/ \
-    -o https://511h1wh89e.execute-api.us-east-1.amazonaws.com/prod/
 ```

--- a/app.py
+++ b/app.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
+import os
+
 import aws_cdk as cdk
 
 from hiscores_tracker.pipeline_stack import PipelineStack
 
 
 app = cdk.App()
-PipelineStack(app, "HiscoresPipelineStack")
+PipelineStack(
+    app,
+    "HiscoresPipelineStack",
+    env=cdk.Environment(
+        account=os.environ["CDK_DEFAULT_ACCOUNT"],
+        region=os.environ["CDK_DEFAULT_REGION"],
+    ),
+)
 
 app.synth()

--- a/app.py
+++ b/app.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
-import os
-
 import aws_cdk as cdk
 
-from hiscores_tracker.hiscores_tracker_stack import HiscoresTrackerStack
+from hiscores_tracker.pipeline_stack import PipelineStack
 
 
 app = cdk.App()
-HiscoresTrackerStack(app, "HiscoresTrackerStack")
+PipelineStack(app, "HiscoresPipelineStack")
 
 app.synth()

--- a/cdk.json
+++ b/cdk.json
@@ -15,6 +15,7 @@
     ]
   },
   "context": {
+    "github_connection_arn": "arn:aws:codestar-connections:us-east-1:212039253172:connection/72414c8f-a6e4-427c-a701-a38759440114",
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
     "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,

--- a/cdk.json
+++ b/cdk.json
@@ -15,8 +15,7 @@
     ]
   },
   "context": {
-    "github_connection_arn": "arn:aws:codestar-connections:us-east-1:212039253172:connection/72414c8f-a6e4-427c-a701-a38759440114",
-    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+"@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
     "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,

--- a/hiscores_tracker/hiscores_tracker_stack.py
+++ b/hiscores_tracker/hiscores_tracker_stack.py
@@ -25,7 +25,7 @@ class HiscoresTrackerStack(Stack):
     def trigger_url_output(self):
         return self._trigger_url_output
 
-    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, construct_id: str, enabled: bool = True, **kwargs) -> None:
 
         super().__init__(scope, construct_id, **kwargs)
 
@@ -34,7 +34,7 @@ class HiscoresTrackerStack(Stack):
         self._query_url = atst.query_api.url
 
         # Provision HiScores API Logger
-        hiscores_logger = HiScoresLogger(self, "OSRSHiScoresLogger", table=atst.table)
+        hiscores_logger = HiScoresLogger(self, "OSRSHiScoresLogger", table=atst.table, enabled=enabled)
 
         # Expose Rest API to trigger orchestrator
         trigger_api = apigw.LambdaRestApi(

--- a/hiscores_tracker/hiscores_tracker_stack.py
+++ b/hiscores_tracker/hiscores_tracker_stack.py
@@ -1,4 +1,4 @@
-from aws_cdk import Stack
+from aws_cdk import CfnOutput, Stack
 from aws_cdk import aws_apigateway as apigw
 from constructs import Construct
 
@@ -16,6 +16,14 @@ class HiscoresTrackerStack(Stack):
     @property
     def trigger_url(self):
         return self._trigger_url
+
+    @property
+    def query_url_output(self):
+        return self._query_url_output
+
+    @property
+    def trigger_url_output(self):
+        return self._trigger_url_output
 
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
 
@@ -36,3 +44,6 @@ class HiscoresTrackerStack(Stack):
         )
         trigger_api.root.add_method("POST")
         self._trigger_url = trigger_api.url
+
+        self._query_url_output = CfnOutput(self, "QueryUrl", value=self._query_url)
+        self._trigger_url_output = CfnOutput(self, "TriggerUrl", value=self._trigger_url)

--- a/hiscores_tracker/pipeline_stack.py
+++ b/hiscores_tracker/pipeline_stack.py
@@ -1,0 +1,76 @@
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk import pipelines
+from constructs import Construct
+
+from .hiscores_tracker_stack import HiscoresTrackerStack
+
+
+class HiscoresTrackerStage(cdk.Stage):
+    @property
+    def query_url(self):
+        return self._query_url
+
+    @property
+    def trigger_url(self):
+        return self._trigger_url
+
+    def __init__(self, scope: Construct, id: str, **kwargs):
+        super().__init__(scope, id, **kwargs)
+        # stack_name keeps updates in-place against the pre-existing CloudFormation stack
+        stack = HiscoresTrackerStack(
+            self, "HiscoresTrackerStack", stack_name="HiscoresTrackerStack"
+        )
+        self._query_url = stack.query_url_output
+        self._trigger_url = stack.trigger_url_output
+
+
+class PipelineStack(Stack):
+    def __init__(self, scope: Construct, id: str, **kwargs):
+        super().__init__(scope, id, **kwargs)
+
+        connection_arn = self.node.try_get_context("github_connection_arn")
+        if not connection_arn:
+            raise ValueError(
+                "CDK context 'github_connection_arn' is required. "
+                "Add it to cdk.json or pass -c github_connection_arn=<arn>."
+            )
+
+        source = pipelines.CodePipelineSource.connection(
+            "awerchniak/cdk-hiscores-tracker",
+            "main",
+            connection_arn=connection_arn,
+        )
+
+        pipeline = pipelines.CodePipeline(
+            self,
+            "Pipeline",
+            synth=pipelines.ShellStep(
+                "Synth",
+                input=source,
+                commands=[
+                    "npm install -g aws-cdk@2",
+                    "pip install -r requirements.txt",
+                    "cdk synth",
+                ],
+            ),
+        )
+
+        stage = HiscoresTrackerStage(self, "Deploy")
+        pipeline.add_stage(
+            stage,
+            post=[
+                pipelines.ShellStep(
+                    "IntegrationTest",
+                    input=source,
+                    env_from_cfn_outputs={
+                        "TRIGGER_URL": stage.trigger_url,
+                        "QUERY_URL": stage.query_url,
+                    },
+                    commands=[
+                        "pip install requests",
+                        "python run_integration_test.py -i $TRIGGER_URL -o $QUERY_URL",
+                    ],
+                )
+            ],
+        )

--- a/hiscores_tracker/pipeline_stack.py
+++ b/hiscores_tracker/pipeline_stack.py
@@ -56,6 +56,7 @@ class PipelineStack(Stack):
                 "Synth",
                 input=source,
                 commands=[
+                    ". ~/.nvm/nvm.sh && nvm install 18 && nvm alias default 18",
                     "npm install -g aws-cdk@2",
                     "pip install -r requirements.txt",
                     "cdk synth",

--- a/hiscores_tracker/pipeline_stack.py
+++ b/hiscores_tracker/pipeline_stack.py
@@ -45,7 +45,7 @@ class PipelineStack(Stack):
 
         source = pipelines.CodePipelineSource.connection(
             "awerchniak/cdk-hiscores-tracker",
-            "main",
+            "mainline",
             connection_arn=connection_arn,
         )
 

--- a/hiscores_tracker/pipeline_stack.py
+++ b/hiscores_tracker/pipeline_stack.py
@@ -56,7 +56,7 @@ class PipelineStack(Stack):
                 "Synth",
                 input=source,
                 commands=[
-                    ". ~/.nvm/nvm.sh && nvm install 18 && nvm alias default 18",
+                    "npm install -g n && n 18 && hash -r",
                     "npm install -g aws-cdk@2",
                     "pip install -r requirements.txt",
                     "cdk synth",

--- a/hiscores_tracker/pipeline_stack.py
+++ b/hiscores_tracker/pipeline_stack.py
@@ -1,5 +1,6 @@
 import aws_cdk as cdk
 from aws_cdk import Stack
+from aws_cdk import aws_codebuild as codebuild
 from aws_cdk import pipelines
 from constructs import Construct
 
@@ -52,11 +53,15 @@ class PipelineStack(Stack):
         pipeline = pipelines.CodePipeline(
             self,
             "Pipeline",
+            code_build_defaults=pipelines.CodeBuildOptions(
+                partial_build_spec=codebuild.BuildSpec.from_object({
+                    "phases": {"install": {"commands": ["n 18"]}}
+                })
+            ),
             synth=pipelines.ShellStep(
                 "Synth",
                 input=source,
                 commands=[
-                    "n 18 && hash -r",
                     "npm install -g aws-cdk@2.0.0",
                     "pip install -r requirements.txt",
                     "cdk synth",

--- a/hiscores_tracker/pipeline_stack.py
+++ b/hiscores_tracker/pipeline_stack.py
@@ -56,6 +56,7 @@ class PipelineStack(Stack):
                 "Synth",
                 input=source,
                 commands=[
+                    "n 18 && hash -r",
                     "npm install -g aws-cdk@2.0.0",
                     "pip install -r requirements.txt",
                     "cdk synth",

--- a/hiscores_tracker/pipeline_stack.py
+++ b/hiscores_tracker/pipeline_stack.py
@@ -1,6 +1,7 @@
 import aws_cdk as cdk
 from aws_cdk import Stack
 from aws_cdk import aws_codebuild as codebuild
+from aws_cdk import aws_iam as iam
 from aws_cdk import aws_ssm as ssm
 from aws_cdk import pipelines
 from constructs import Construct
@@ -54,7 +55,15 @@ class PipelineStack(Stack):
             code_build_defaults=pipelines.CodeBuildOptions(
                 partial_build_spec=codebuild.BuildSpec.from_object({
                     "phases": {"install": {"commands": ["n 18"]}}
-                })
+                }),
+                role_policy=[
+                    iam.PolicyStatement(
+                        actions=["ssm:GetParameter", "ssm:GetParameters"],
+                        resources=[
+                            f"arn:aws:ssm:{self.region}:{self.account}:parameter/hiscores-tracker/github-connection-arn"
+                        ],
+                    )
+                ],
             ),
             synth=pipelines.ShellStep(
                 "Synth",

--- a/hiscores_tracker/pipeline_stack.py
+++ b/hiscores_tracker/pipeline_stack.py
@@ -15,11 +15,18 @@ class HiscoresTrackerStage(cdk.Stage):
     def trigger_url(self):
         return self._trigger_url
 
-    def __init__(self, scope: Construct, id: str, **kwargs):
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        enabled: bool = True,
+        stack_name: str = None,
+        **kwargs,
+    ):
         super().__init__(scope, id, **kwargs)
-        # stack_name keeps updates in-place against the pre-existing CloudFormation stack
+        stack_kwargs = {"stack_name": stack_name} if stack_name is not None else {}
         stack = HiscoresTrackerStack(
-            self, "HiscoresTrackerStack", stack_name="HiscoresTrackerStack"
+            self, "HiscoresTrackerStack", enabled=enabled, **stack_kwargs
         )
         self._query_url = stack.query_url_output
         self._trigger_url = stack.trigger_url_output
@@ -56,16 +63,18 @@ class PipelineStack(Stack):
             ),
         )
 
-        stage = HiscoresTrackerStage(self, "Deploy")
+        # Beta: event trigger disabled so it never polls the HiScores API on schedule.
+        # Integration tests run here; passing them promotes to Prod.
+        beta = HiscoresTrackerStage(self, "Beta", enabled=False)
         pipeline.add_stage(
-            stage,
+            beta,
             post=[
                 pipelines.ShellStep(
                     "IntegrationTest",
                     input=source,
                     env_from_cfn_outputs={
-                        "TRIGGER_URL": stage.trigger_url,
-                        "QUERY_URL": stage.query_url,
+                        "TRIGGER_URL": beta.trigger_url,
+                        "QUERY_URL": beta.query_url,
                     },
                     commands=[
                         "pip install requests",
@@ -74,3 +83,9 @@ class PipelineStack(Stack):
                 )
             ],
         )
+
+        # Prod: stack_name preserves the existing CloudFormation stack in-place.
+        prod = HiscoresTrackerStage(
+            self, "Prod", stack_name="HiscoresTrackerStack"
+        )
+        pipeline.add_stage(prod)

--- a/hiscores_tracker/pipeline_stack.py
+++ b/hiscores_tracker/pipeline_stack.py
@@ -56,8 +56,7 @@ class PipelineStack(Stack):
                 "Synth",
                 input=source,
                 commands=[
-                    "npm install -g n && n 18 && hash -r",
-                    "npm install -g aws-cdk@2",
+                    "npm install -g aws-cdk@2.0.0",
                     "pip install -r requirements.txt",
                     "cdk synth",
                 ],

--- a/hiscores_tracker/pipeline_stack.py
+++ b/hiscores_tracker/pipeline_stack.py
@@ -45,7 +45,7 @@ class PipelineStack(Stack):
 
         source = pipelines.CodePipelineSource.connection(
             "awerchniak/cdk-hiscores-tracker",
-            "add-codepipeline",
+            "mainline",
             connection_arn=connection_arn,
         )
 

--- a/hiscores_tracker/pipeline_stack.py
+++ b/hiscores_tracker/pipeline_stack.py
@@ -1,6 +1,7 @@
 import aws_cdk as cdk
 from aws_cdk import Stack
 from aws_cdk import aws_codebuild as codebuild
+from aws_cdk import aws_ssm as ssm
 from aws_cdk import pipelines
 from constructs import Construct
 
@@ -37,12 +38,9 @@ class PipelineStack(Stack):
     def __init__(self, scope: Construct, id: str, **kwargs):
         super().__init__(scope, id, **kwargs)
 
-        connection_arn = self.node.try_get_context("github_connection_arn")
-        if not connection_arn:
-            raise ValueError(
-                "CDK context 'github_connection_arn' is required. "
-                "Add it to cdk.json or pass -c github_connection_arn=<arn>."
-            )
+        connection_arn = ssm.StringParameter.value_from_lookup(
+            self, "/hiscores-tracker/github-connection-arn"
+        )
 
         source = pipelines.CodePipelineSource.connection(
             "awerchniak/cdk-hiscores-tracker",

--- a/hiscores_tracker/pipeline_stack.py
+++ b/hiscores_tracker/pipeline_stack.py
@@ -45,7 +45,7 @@ class PipelineStack(Stack):
 
         source = pipelines.CodePipelineSource.connection(
             "awerchniak/cdk-hiscores-tracker",
-            "mainline",
+            "add-codepipeline",
             connection_arn=connection_arn,
         )
 

--- a/hiscores_tracker/util.py
+++ b/hiscores_tracker/util.py
@@ -32,7 +32,7 @@ def package_lambda(
             scope,
             function_name,
             description=description,
-            runtime=_lambda.Runtime.PYTHON_3_12,
+            runtime=_lambda.Runtime.PYTHON_3_9,
             code=_lambda.Code.from_asset(code_dir),
             handler=f"{handler_name}.handler.handler",
             environment=environment,

--- a/hiscores_tracker/util.py
+++ b/hiscores_tracker/util.py
@@ -32,7 +32,7 @@ def package_lambda(
             scope,
             function_name,
             description=description,
-            runtime=_lambda.Runtime.PYTHON_3_8,
+            runtime=_lambda.Runtime.PYTHON_3_12,
             code=_lambda.Code.from_asset(code_dir),
             handler=f"{handler_name}.handler.handler",
             environment=environment,


### PR DESCRIPTION
## Summary

- Adds a self-mutating AWS CodePipeline (`PipelineStack`) that triggers on every push to `mainline`
- Pipeline stages: Synth → Beta (EventBridge disabled) + Integration Tests → Prod (in-place update of existing `HiscoresTrackerStack`, preserving DynamoDB data)
- Reads the GitHub CodeStar connection ARN from SSM Parameter Store (`/hiscores-tracker/github-connection-arn`) instead of committing it to source — repo is public
- Upgrades Lambda runtime from Python 3.8 to 3.9 (required by `idna` dependency's type hints)
- Updates README with CI/CD architecture overview and new onboarding steps

## Key implementation details

- `HiscoresTrackerStage` wraps `HiscoresTrackerStack` as a CDK Stage; `enabled=False` on Beta disables the EventBridge schedule so it never polls the live HiScores API
- `stack_name="HiscoresTrackerStack"` on the Prod stage targets the existing CloudFormation stack in-place
- `CfnOutput` on both API URLs allows the integration test step to inject them via `env_from_cfn_outputs`
- `code_build_defaults.partial_build_spec` applies `n 18` globally to all CodeBuild projects (Synth, SelfMutate, assets, integration test) — required because CDK's jsii uses `String.replaceAll` which needs Node 15+
- `code_build_defaults.role_policy` grants `ssm:GetParameter` to all CodeBuild roles so `value_from_lookup` resolves at synth time

## Test plan

- [ ] Pipeline run on `add-codepipeline` branch completes fully (Synth → SelfMutate → Beta → Integration Tests → Prod)
- [ ] After merge, push to `mainline` triggers pipeline automatically (SelfMutate switches the watched branch on the prior run)
- [ ] Integration tests pass on Beta before Prod is touched